### PR TITLE
Multiple breadcrumb params (updated)

### DIFF
--- a/lib/gretel/crumbs.rb
+++ b/lib/gretel/crumbs.rb
@@ -17,29 +17,32 @@ module Gretel
         all[name] = block
       end
       
-      def get_crumb(name, object = nil)
+      def get_crumb(name, *params)
         raise "Crumb '#{name}' not found." unless all[name]
         
-        @object = object # share the object so we can call it from link() and parent()
+        @params = params # share the params so we can call it from link() and parent()
         @link = nil
         @parent = nil
         
-        all[name].call(object)
+        all[name].call(*params)
         Gretel::Crumb.new(@link, @parent)
       end
       
       def link(text, url)
-        text = text.call(@object) if text.is_a?(Proc)
-        url = url.call(@object) if url.is_a?(Proc)
+        text = text.call(*@params) if text.is_a?(Proc)
+        url = url.call(*@params) if url.is_a?(Proc)
         
         @link = Gretel::Link.new(text, url)
       end
       
-      def parent(name, object = nil)
-        name = name.call(@object) if name.is_a?(Proc)
-        object = object.call(@object) if object.is_a?(Proc)
+      def parent(name, *params)
+        name = name.call(*@params) if name.is_a?(Proc)
 
-        @parent = Gretel::Parent.new(name, object)
+        params.each_with_index do |param, i|
+          params[i] = param.call(&@params) if param.is_a?(Proc)
+        end
+
+        @parent = Gretel::Parent.new(name, *params)
       end
     end
   end

--- a/lib/gretel/helper_methods.rb
+++ b/lib/gretel/helper_methods.rb
@@ -10,14 +10,14 @@ module Gretel
     
     def breadcrumb(*args)
       options = args.extract_options!
-      name, object = args[0], args[1]
+      name, params = args[0], args[1..-1]
       
       if name
         @_breadcrumb_name = name
-        @_breadcrumb_object = object
+        @_breadcrumb_params = params
       else
         if @_breadcrumb_name
-          crumb = breadcrumb_for(@_breadcrumb_name, @_breadcrumb_object, options)
+          crumb = breadcrumb_for(@_breadcrumb_name, *@_breadcrumb_params, options)
         elsif options[:show_root_alone]
           crumb = breadcrumb_for(:root, options)
         end
@@ -36,14 +36,14 @@ module Gretel
       options[:link_last] = true
       separator = (options[:separator] || "&gt;").html_safe
 
-      name, object = args[0], args[1]
+      name, params = args[0], args[1..-1]
       
-      crumb = Crumbs.get_crumb(name, object)
+      crumb = Crumbs.get_crumb(name, *params)
       out = link_to_if(link_last, crumb.link.text, crumb.link.url)
       
       while parent = crumb.parent
         last_parent = parent.name
-        crumb = Crumbs.get_crumb(parent.name, parent.object)
+        crumb = Crumbs.get_crumb(parent.name, *parent.params)
         out = link_to(crumb.link.text, crumb.link.url) + " " + separator + " " + out
       end
       

--- a/lib/gretel/parent.rb
+++ b/lib/gretel/parent.rb
@@ -1,9 +1,9 @@
 module Gretel
   class Parent
-    attr_accessor :name, :object
+    attr_accessor :name, :params
     
-    def initialize(name, object)
-      @name, @object = name, object
+    def initialize(name, *params)
+      @name, @params = name, params
     end
   end
 end


### PR DESCRIPTION
Here's an updated pull request. Thanks!

Adding support for multiple parameters for breadcrumb. E.g.:

``` ruby
crumb :crouton do |size, flavor| ...
```

``` ruby
breadcrumb :crouton, "large", "herbaceous"
```
