### PR TITLE
Fix style for Zurb Foundation 5

### DIFF
--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -19,7 +19,7 @@ module Gretel
       ol: { container_tag: :ol, fragment_tag: :li },
       ul: { container_tag: :ul, fragment_tag: :li },
       bootstrap: { container_tag: :ol, fragment_tag: :li, class: "breadcrumb", current_class: "active" },
-      foundation5: { container_tag: :ul, fragment_tag: :li, class: "breadcrumb", current_class: "current" }
+      foundation5: { container_tag: :ul, fragment_tag: :li, class: "breadcrumbs", current_class: "current" }
     }
 
     def initialize(context, breadcrumb_key, *breadcrumb_args)


### PR DESCRIPTION
Updated Foundation style according to this documentation page: http://foundation.zurb.com/docs/components/breadcrumbs.html
