### PR TITLE
Make these instance vars publicly readable

### DIFF
--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -55,9 +55,11 @@ module Gretel
       end
     end
 
+    attr_reader :breadcrumb_key, :breadcrumb_args
+
     private
 
-    attr_reader :context, :breadcrumb_key, :breadcrumb_args
+    attr_reader :context
 
     # Returns merged options for rendering breadcrumbs.
     def options_for_render(options = {})


### PR DESCRIPTION
Make these instance vars publicly accessible, so they can be used to generate a `cache_key` for caching the breadcrumbs.