### PR TITLE
jRuby issue with Rails::Application constant

### DIFF
--- a/lib/gretel.rb
+++ b/lib/gretel.rb
@@ -16,8 +16,8 @@ module Gretel
     # breadcrumbs set in engines.
     def breadcrumb_paths
       @breadcrumb_paths ||= begin
-        engines = Rails::Application::Railties.respond_to?(:engines) ?
-          Rails::Application::Railties.engines :
+        engines = Rails::Engine::Railties.respond_to?(:engines) ?
+          Rails::Engine::Railties.engines :
           Rails::Engine.subclasses.map(&:instance)
 
         engine_roots = engines.map { |e| e.config.root }


### PR DESCRIPTION
For some reason trying to use the Rails::Application::Railties constant breaks on jRuby 1.7. I don't fully understand why that is the case, but the same issue was present in spree (spree/spree_auth_devise#169) with the following fix: spree/spree_auth_devise@967afac.