### PR TITLE
Fix semantic breadcrumb when last item has no link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 2.1.0
   - 2.0.0

--- a/README.md
+++ b/README.md
@@ -348,11 +348,12 @@ To contribute:
 1. Fork the project
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Make your changes
-4. Add tests
-5. Run `rake` to make sure all tests pass
-6. Commit your changes (`git commit -am 'Add new feature'`)
-7. Push to the branch (`git push origin my-new-feature`)
-8. Create new pull request
+4. Add/Fix tests
+5. Prepare database for testing: `cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..`
+6. Run `rake` to make sure all tests pass
+7. Commit your changes (`git commit -am 'Add new feature'`)
+8. Push to the branch (`git push origin my-new-feature`)
+9. Create new pull request
 
 Thanks.
 

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -175,7 +175,7 @@ module Gretel
 
         # The current link is handled a little differently, and is only linked if specified in the options
         current_link = links.last
-        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], class: options[:current_class])
+        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], class: options[:current_class], current_link: current_link.url)
 
         # Build the final HTML
         html_fragments = []
@@ -209,7 +209,14 @@ module Gretel
       def render_semantic_fragment(fragment_tag, text, url, options = {})
         if fragment_tag
           text = content_tag(:span, text, itemprop: "title")
-          text = breadcrumb_link_to(text, url, itemprop: "url") if url.present?
+
+          if url.present?
+            text = breadcrumb_link_to(text, url, itemprop: "url")
+          elsif options[:current_link].present?
+            current_url = "#{root_url}#{options[:current_link].gsub(/^\//, '')}"
+            text = text + tag(:meta, itemprop: "url", content: current_url)
+          end
+
           content_tag(fragment_tag, text, class: options[:class], itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
         elsif url.present?
           content_tag(:span, breadcrumb_link_to(content_tag(:span, text, itemprop: "title"), url, class: options[:class], itemprop: "url"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -365,7 +365,7 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "custom semantic container and fragment tags" do
     breadcrumb :basic
-    assert_dom_equal %Q{<c class="breadcrumbs"><f itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/" itemprop="url"><span itemprop="title">Home</span></a></f> &rsaquo; <f class="current" itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">About</span></f></c>},
+    assert_dom_equal %Q{<c class="breadcrumbs"><f itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><a itemprop="url" href="/"><span itemprop="title">Home</span></a></f> &rsaquo; <f class="current" itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">About</span><meta itemprop="url" content="http://test.host/about" /></f></c>},
                  breadcrumbs(container_tag: :c, fragment_tag: :f, semantic: true).to_s
   end
 


### PR DESCRIPTION
### Context:
**Semantic** breadcrumb when the last item should **not show the last Link**.

### The issue:
Google Developer Structure Data Tool does not validate the last breadcrumb item.
The last item in the breadcrumb was not setting any `url` property for the item.

### Solution:
- add meta tag with `itemprop=url` and content
- the meta url `content` sould be a valid url, not just a path

I also updated the **contribute notes** with the database prepare because it was needed to run the tests.

Reference: https://developers.google.com/structured-data/testing-tool/

### Before:
```html
<ol class="breadcrumb">
  <li itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a itemprop="url" href="/"><span itemprop="title">Início</span></a>
  </li>
  <li itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a itemprop="url" href="/setores/ti-e-telecom"><span itemprop="title">Ti E Telecom</span></a>
  </li>
  <li itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a itemprop="url" href="/trabalhar-na-love-mondays"><span itemprop="title">Love Mondays</span></a>
  </li>
  <li class="active" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <span itemprop="title">Avaliações</span>
  </li>
</ol>
```
![screen shot 2015-04-30 at 10 01 36 am](https://cloud.githubusercontent.com/assets/1071893/7413193/00c82206-ef20-11e4-8a50-74496fe2d6b7.png)

### After:
```html
<ol class="breadcrumb">
  <li itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a itemprop="url" href="/"><span itemprop="title">Início</span></a>
  </li>
  <li itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a itemprop="url" href="/setores/ti-e-telecom"><span itemprop="title">Ti E Telecom</span></a>
  </li>
  <li itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <a itemprop="url" href="/trabalhar-na-love-mondays"><span itemprop="title">Love Mondays</span></a>
  </li>
  <li class="active" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
    <span itemprop="title">Avaliações</span>
    <meta itemprop="url" content="http://www.example.com//trabalhar-na-love-mondays/avaliacoes" />
  </li>
</ol>
```
![screen shot 2016-01-13 at 11 43 27 pm](https://cloud.githubusercontent.com/assets/1071893/12313538/87dc8886-ba4f-11e5-9574-57c74148d24d.png)
