### PR TITLE
Switch alias_method_chain to Module#prepend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
+sudo: false
 rvm:
+  - 2.2.0
   - 2.1.0
   - 2.0.0
   - 1.9.3

--- a/gemfiles/Gemfile-rails.3.2.x
+++ b/gemfiles/Gemfile-rails.3.2.x
@@ -15,3 +15,5 @@ gem "jquery-rails"
 
 # To use debugger
 # gem 'debugger'
+
+gem 'test-unit', '~> 3.0' if RUBY_VERSION >= "2.2"

--- a/lib/gretel/deprecated/default_style_key.rb
+++ b/lib/gretel/deprecated/default_style_key.rb
@@ -1,11 +1,25 @@
-Gretel::Renderer.class_eval do
-  def options_for_style_with_default_style_key(style_key)
-    if style_key == :default
-      Gretel.show_deprecation_warning "The :default style key is now called :inline. Please use `breadcrumbs style: :inline` instead or omit it, as it is the default."
-      style_key = :inline
+if RUBY_VERSION < "2.0"
+  Gretel::Renderer.class_eval do
+    def options_for_style_with_default_style_key(style_key)
+      if style_key == :default
+        Gretel.show_deprecation_warning "The :default style key is now called :inline. Please use `breadcrumbs style: :inline` instead or omit it, as it is the default."
+        style_key = :inline
+      end
+      options_for_style_without_default_style_key(style_key)
     end
-    options_for_style_without_default_style_key(style_key)
+
+    alias_method_chain :options_for_style, :default_style_key
+  end
+else
+  module DeprecatedDefaultStyleKey
+    def options_for_style(style_key)
+      if style_key == :default
+        Gretel.show_deprecation_warning "The :default style key is now called :inline. Please use `breadcrumbs style: :inline` instead or omit it, as it is the default."
+        style_key = :inline
+      end
+      super(style_key)
+    end
   end
 
-  alias_method_chain :options_for_style, :default_style_key
+  Gretel::Renderer.send :prepend, DeprecatedDefaultStyleKey
 end

--- a/lib/gretel/deprecated/show_root_alone.rb
+++ b/lib/gretel/deprecated/show_root_alone.rb
@@ -1,12 +1,27 @@
-Gretel::Renderer.class_eval do
-  def options_for_render_with_show_root_alone(options = {})
-    options = options_for_render_without_show_root_alone(options)
-    if show_root_alone = options.delete(:show_root_alone)
-      Gretel.show_deprecation_warning "The :show_root_alone option is deprecated and will be removed in Gretel v4.0.0. Use `breadcrumbs(display_single_fragment: #{show_root_alone.inspect})` instead."
-      options[:display_single_fragment] = show_root_alone
+if RUBY_VERSION < "2.0"
+  Gretel::Renderer.class_eval do
+    def options_for_render_with_show_root_alone(options = {})
+      options = options_for_render_without_show_root_alone(options)
+      if show_root_alone = options.delete(:show_root_alone)
+        Gretel.show_deprecation_warning "The :show_root_alone option is deprecated and will be removed in Gretel v4.0.0. Use `breadcrumbs(display_single_fragment: #{show_root_alone.inspect})` instead."
+        options[:display_single_fragment] = show_root_alone
+      end
+      options
     end
-    options
+
+    alias_method_chain :options_for_render, :show_root_alone
+  end
+else
+  module DeprecatedShowRootAlone
+    def options_for_render(options = {})
+      options = super(options)
+      if show_root_alone = options.delete(:show_root_alone)
+        Gretel.show_deprecation_warning "The :show_root_alone option is deprecated and will be removed in Gretel v4.0.0. Use `breadcrumbs(display_single_fragment: #{show_root_alone.inspect})` instead."
+        options[:display_single_fragment] = show_root_alone
+      end
+      options
+    end
   end
 
-  alias_method_chain :options_for_render, :show_root_alone
+  Gretel::Renderer.send :prepend, DeprecatedShowRootAlone
 end

--- a/lib/gretel/deprecated/yield_links.rb
+++ b/lib/gretel/deprecated/yield_links.rb
@@ -1,4 +1,6 @@
-Gretel::ViewHelpers.class_eval do
+if RUBY_VERSION < "2.0"
+  Gretel::ViewHelpers.class_eval do
+
   def breadcrumbs_with_yield_links(options = {})
     if block_given?
       Gretel.show_deprecation_warning(
@@ -17,4 +19,26 @@ Gretel::ViewHelpers.class_eval do
   end
 
   alias_method_chain :breadcrumbs, :yield_links
+  end
+else
+  module DeprecatedYieldLinks
+    def breadcrumbs(options = {})
+      if block_given?
+        Gretel.show_deprecation_warning(
+            "Calling `breadcrumbs` with a block has been deprecated and will be removed in Gretel version 4.0. Please use `tap` instead. Example:\n" +
+                "\n" +
+                "  breadcrumbs(autoroot: false).tap do |links|\n" +
+                "    if links.any?\n" +
+                "      # process links here\n" +
+                "    end\n" +
+                "  end\n"
+        )
+        yield gretel_renderer.render(options)
+      else
+        super(options)
+      end
+    end
+  end
+
+  Gretel::ViewHelpers.send :prepend, DeprecatedYieldLinks
 end


### PR DESCRIPTION
Fixes #65 

Not sure how I could DRY the two variants of the code without making it less easy to understand. Suggestions welcome. Maybe dropping Ruby 1.9 support in future is an option.