### PR TITLE
Use on_load to fix load order problem with rails-controller-testing

### DIFF
--- a/lib/gretel.rb
+++ b/lib/gretel.rb
@@ -79,4 +79,6 @@ module Gretel
   end
 end
 
-ActionView::Base.send :include, Gretel::ViewHelpers
+ActiveSupport.on_load(:action_view) do
+  ActionView::Base.send :include, Gretel::ViewHelpers
+end


### PR DESCRIPTION
If gretel is used with rails-controller-testing some tests fail since gretel does not use the on_load event: rails/rails-controller-testing#24
