### PR TITLE
Use ActiveSupport.on_load looks to inject behavior into ActionView::Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fix loading of ActionView helpers in combination with RSpec and `rails-controller-testing`. (see [rails-controller-testing/issues#24](https://github.com/rails/rails-controller-testing/issues/24))
+
 ## Version 3.0.8
 * Parent breadcrumbs can now also be inferred from models responding to `model_name`.
 

--- a/lib/gretel.rb
+++ b/lib/gretel.rb
@@ -21,7 +21,7 @@ module Gretel
           Rails::Engine.subclasses.map(&:instance)
 
         engine_roots = engines.map { |e| e.config.root }
-        
+
         [*engine_roots, Rails.root].map do |root|
           [root.join("config", "breadcrumbs.rb"),
            root.join("config", "breadcrumbs", "**", "*.rb"),
@@ -59,7 +59,7 @@ module Gretel
     end
 
     # Registers a style for later use.
-    # 
+    #
     #   Gretel.register_style :ul, { container_tag: :ul, fragment_tag: :li }
     def register_style(style, options)
       Gretel::Renderer.register_style style, options
@@ -69,7 +69,7 @@ module Gretel
     attr_writer :reload_environments
 
     # Yields this +Gretel+ to be configured.
-    # 
+    #
     #   Gretel.configure do |config|
     #     config.reload_environments << "staging"
     #   end
@@ -79,4 +79,6 @@ module Gretel
   end
 end
 
-ActionView::Base.send :include, Gretel::ViewHelpers
+ActiveSupport.on_load(:action_view) do
+  Gretel::ViewHelpers
+end


### PR DESCRIPTION
rails/rails-controller-testing#24 suggests `ActiveSupport.on_load` may address issues with this gem and Rails 5.