### PR TITLE
mime-types 3 requires ruby 2

### DIFF
--- a/gemfiles/Gemfile-rails.4.0.x
+++ b/gemfiles/Gemfile-rails.4.0.x
@@ -8,6 +8,12 @@ gem "sqlite3"
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 
+if RUBY_VERSION > '1.9.3'
+  gem 'mime-types'
+else
+  gem 'mime-types', '2.99'
+end
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/gemfiles/Gemfile-rails.4.1.x
+++ b/gemfiles/Gemfile-rails.4.1.x
@@ -8,6 +8,12 @@ gem "sqlite3"
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 
+if RUBY_VERSION > '1.9.3'
+  gem 'mime-types'
+else
+  gem 'mime-types', '2.99'
+end
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing


### PR DESCRIPTION
mime-types 3+ requires ruby 2+.
So if we're still supporting ruby 1, we need to bundle mime-types < 3.

This fixes recent CI failures: https://travis-ci.org/lassebunk/gretel/builds