### PR TITLE
Add root_key option for different namespaces

### DIFF
--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -6,6 +6,7 @@ module Gretel
       posttext: "",
       separator: "",
       autoroot: true,
+      root_key: nil,
       display_single_fragment: false,
       link_current: false,
       link_current_to_request_path: true,
@@ -79,9 +80,11 @@ module Gretel
     def links_for_render(options = {})
       out = links.dup
 
+      root_key = options[:root_key] || :root
+
       # Handle autoroot
-      if options[:autoroot] && out.map(&:key).exclude?(:root) && Gretel::Crumbs.crumb_defined?(:root)
-        out.unshift *Gretel::Crumb.new(context, :root).links
+      if options[:autoroot] && out.map(&:key).exclude?(root_key) && Gretel::Crumbs.crumb_defined?(root_key)
+        out.unshift *Gretel::Crumb.new(context, root_key).links
       end
 
       # Set current link to actual path

--- a/test/dummy/config/breadcrumbs.rb
+++ b/test/dummy/config/breadcrumbs.rb
@@ -1,3 +1,7 @@
 crumb :root do
   link "Home", root_path
 end
+
+crumb :admin_root do
+  link "Admin", root_path
+end

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -383,6 +383,12 @@ class HelperMethodsTest < ActionView::TestCase
     end
   end
 
+  test "autoroot with custom root_key" do
+    breadcrumb :basic
+    assert_dom_equal %Q{<div class="breadcrumbs"><a href="/">Admin</a> &rsaquo; <span class="current">About</span></div>},
+                      breadcrumbs(root_key: :admin_root).to_s
+  end
+
   test "register style" do
     Gretel.register_style :test_style, { container_tag: :one, fragment_tag: :two }
 


### PR DESCRIPTION
This is somewhat similar to https://github.com/lassebunk/gretel/issues/48. 

I have 2 different namespace (`application` and `admin`), hence created 2 breadcrumbs file (`admin.rb` and `application.rb`) with 2 different root paths: `admin_root` and `root` respectively. Breadcrumbs rendering in application works like a charm. However in admin, it doesn't render `admin_root` but renders `root` instead. There is solution to disable `autoroot` but it doesn't look good to me. Therefore I forked the repo and modified a little bit to accept additional option `root_key`. When present, with the help of `autoroot`, it will render the desired `root`.
