### PR TITLE
Fixed documentation to avoid deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ end
 If you supply a block to the `breadcrumbs` method, it will yield an array with the breadcrumb links so you can build the breadcrumbs HTML manually:
 
 ```erb
-<% breadcrumbs do |links| %>
+<% breadcrumbs(autoroot: false).tap do |links| %>
   <% if links.any? %>
     You are here:
     <% links.each do |link| %>


### PR DESCRIPTION
When I used this gem, the logs noted deprecation warning. So I fixed README to avoid being pointed out.  

```
[Gretel] Calling `breadcrumbs` with a block has been deprecated and will be removed in Gretel version 4.0. Please use `tap` instead. Example:

 breadcrumbs(autoroot: false).tap do |links|
    if links.any?
      # process links here
    end
 end
```