### PR TITLE
remove warning "`*' interpreted as argument prefix"

### DIFF
--- a/lib/gretel/crumb.rb
+++ b/lib/gretel/crumb.rb
@@ -13,7 +13,7 @@ module Gretel
       raise ArgumentError, "Breadcrumb :#{key} not found." unless block
       @key = key
       @context = context
-      instance_exec *args, &block
+      instance_exec(*args, &block)
     end
 
     # Sets link of the breadcrumb.

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -81,7 +81,7 @@ module Gretel
 
       # Handle autoroot
       if options[:autoroot] && out.map(&:key).exclude?(:root) && Gretel::Crumbs.crumb_defined?(:root)
-        out.unshift *Gretel::Crumb.new(context, :root).links
+        out.unshift(*Gretel::Crumb.new(context, :root).links)
       end
 
       # Set current link to actual path
@@ -114,7 +114,7 @@ module Gretel
         links = crumb.links.dup
 
         # Get parent links
-        links.unshift *parent_links_for(crumb)
+        links.unshift(*parent_links_for(crumb))
 
         links
       else
@@ -126,7 +126,7 @@ module Gretel
     def parent_links_for(crumb)
       links = []
       while crumb = crumb.parent
-        links.unshift *crumb.links
+        links.unshift(*crumb.links)
       end
       links
     end


### PR DESCRIPTION
remove warning message like this.
```
/home/travis/build/suzan2go/gretel/lib/gretel/crumb.rb:16: warning: `*' interpreted as argument prefix
/home/travis/build/suzan2go/gretel/lib/gretel/renderer.rb:84: warning: `*' interpreted as argument prefix
/home/travis/build/suzan2go/gretel/lib/gretel/renderer.rb:117: warning: `*' interpreted as argument prefix
/home/travis/build/suzan2go/gretel/lib/gretel/renderer.rb:129: warning: `*' interpreted as argument prefix
```