### PR TITLE
Feature/schema org breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 3.0.10
+* Replaces data-vocabulary markup as google doesn't support it and now uses schema.org markup
+* simplified semantic fragment rendering
+
 ## Version 3.0.9
 * Adds breadcrumbs option `link_current_to_request_path` to link the current breadcrumb to the request path(#28 via #29)
 * Fixes semantic breadcrumbs when the last item has no link (via #55)

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -193,8 +193,14 @@ module Gretel
         end
 
         html = html_fragments.join(" ").html_safe
-        content_tag(options[:container_tag], html, id: options[:id], class: options[:class], itemscope: "", itemtype: "http://schema.org/BreadcrumbList")
-      end
+        
+        if options[:semantic]
+          content_tag(options[:container_tag], html, id: options[:id], class: options[:class], itemscope: "", itemtype: "https://schema.org/BreadcrumbList")
+        else
+          content_tag(options[:container_tag], html, id: options[:id], class: options[:class])
+        end
+
+     end
 
       alias :to_s :render
 
@@ -220,6 +226,7 @@ module Gretel
         end
 
         text = text + tag(:meta, itemprop:"position", content: "#{position}")
+        
         content_tag(fragment_tag.to_sym, text, class: options[:class], itemprop: "itemListElement", itemscope: "", itemtype: "https://schema.org/ListItem")
       end
 

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -170,13 +170,14 @@ module Gretel
         return "" if links.empty?
 
         # Loop through all but the last (current) link and build HTML of the fragments
-        fragments = links[0..-2].map do |link|
-          render_fragment(options[:fragment_tag], link.text, link.url, options[:semantic])
+        fragments = links[0..-2].map.with_index do |link, index|
+          render_fragment(options[:fragment_tag], link.text, link.url, options[:semantic], index + 1)
         end
 
         # The current link is handled a little differently, and is only linked if specified in the options
         current_link = links.last
-        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], class: options[:current_class], current_link: current_link.url)
+        position = links.size
+        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], position, class: options[:current_class], current_link: current_link.url)
 
         # Build the final HTML
         html_fragments = []
@@ -192,38 +193,34 @@ module Gretel
         end
 
         html = html_fragments.join(" ").html_safe
-        content_tag(options[:container_tag], html, id: options[:id], class: options[:class])
+        content_tag(options[:container_tag], html, id: options[:id], class: options[:class], itemscope: "", itemtype: "http://schema.org/BreadcrumbList")
       end
 
       alias :to_s :render
 
       # Renders HTML for a breadcrumb fragment, i.e. a breadcrumb link.
-      def render_fragment(fragment_tag, text, url, semantic, options = {})
+      def render_fragment(fragment_tag, text, url, semantic, position, options = {})
         if semantic
-          render_semantic_fragment(fragment_tag, text, url, options)
+          render_semantic_fragment(fragment_tag, text, url, position, options)
         else
           render_nonsemantic_fragment(fragment_tag, text, url, options)
         end
       end
 
       # Renders semantic fragment HTML.
-      def render_semantic_fragment(fragment_tag, text, url, options = {})
-        if fragment_tag
-          text = content_tag(:span, text, itemprop: "title")
+      def render_semantic_fragment(fragment_tag, text, url, position, options = {})
+        fragment_tag = fragment_tag || 'span'
+        text = content_tag(:span, text, itemprop: "name")
 
-          if url.present?
-            text = breadcrumb_link_to(text, url, itemprop: "url")
-          elsif options[:current_link].present?
-            current_url = "#{root_url}#{options[:current_link].gsub(/^\//, '')}"
-            text = text + tag(:meta, itemprop: "url", content: current_url)
-          end
-
-          content_tag(fragment_tag, text, class: options[:class], itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
-        elsif url.present?
-          content_tag(:span, breadcrumb_link_to(content_tag(:span, text, itemprop: "title"), url, class: options[:class], itemprop: "url"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
-        else
-          content_tag(:span, content_tag(:span, text, class: options[:class], itemprop: "title"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
+        if url.present?
+          text = breadcrumb_link_to(text, url, itemprop: "item")
+        elsif options[:current_link].present?
+          current_url = "#{root_url}#{options[:current_link].gsub(/^\//, '')}"
+          text = text + tag(:meta, itemprop: "item", content: current_url)
         end
+
+        text = text + tag(:meta, itemprop:"position", content: "#{position}")
+        content_tag(fragment_tag.to_sym, text, class: options[:class], itemprop: "itemListElement", itemscope: "", itemtype: "https://schema.org/ListItem")
       end
 
       # Renders regular, non-semantic fragment HTML.

--- a/lib/gretel/version.rb
+++ b/lib/gretel/version.rb
@@ -1,3 +1,3 @@
 module Gretel
-  VERSION = "3.0.9"
+  VERSION = "3.0.10"
 end

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,29 +1,28 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130122163051) do
+ActiveRecord::Schema.define(version: 2013_01_22_163051) do
 
-  create_table "issues", :force => true do |t|
-    t.string   "title"
-    t.integer  "project_id"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+  create_table "issues", force: :cascade do |t|
+    t.string "title"
+    t.integer "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "projects", :force => true do |t|
-    t.string   "name"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+  create_table "projects", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -1,9 +1,9 @@
-require 'test_helper'
+require "test_helper"
 
 class HelperMethodsTest < ActionView::TestCase
   include Gretel::ViewHelpers
 
-  self.fixture_path = File.expand_path("../../test/fixtures", __FILE__)
+  self.fixture_path = File.expand_path("../test/fixtures", __dir__)
   fixtures :all
 
   helper :application
@@ -21,50 +21,50 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "basic breadcrumb" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "breadcrumb with root" do
     breadcrumb :with_root
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "breadcrumb with parent" do
     breadcrumb :with_parent
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">About</a> &rsaquo; <span class="current">Contact</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">About</a> &rsaquo; <span class="current">Contact</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "breadcrumb with autopath" do
     breadcrumb :with_autopath, projects(:one)
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test Project</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test Project</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "breadcrumb with parent object" do
     breadcrumb :with_parent_object, issues(:one)
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/projects/1">Test Project</a> &rsaquo; <span class="current">Test Issue</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/projects/1">Test Project</a> &rsaquo; <span class="current">Test Issue</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "multiple links" do
     breadcrumb :multiple_links
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about/contact">Contact</a> &rsaquo; <span class="current">Contact form</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about/contact">Contact</a> &rsaquo; <span class="current">Contact form</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "multiple links with parent" do
     breadcrumb :multiple_links_with_parent
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">About</a> &rsaquo; <a href="/about/contact">Contact</a> &rsaquo; <span class="current">Contact form</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">About</a> &rsaquo; <a href="/about/contact">Contact</a> &rsaquo; <span class="current">Contact form</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "semantic breadcrumb" do
     breadcrumb :with_root
-    assert_dom_equal %Q{<div class="breadcrumbs"><span itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/" itemprop="url"><span itemprop="title">Home</span></a></span> &rsaquo; <span itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><span class="current" itemprop="title">About</span></span></div>},
-                 breadcrumbs(semantic: true).to_s
+    assert_dom_equal %(<div class="breadcrumbs" itemscope="#{itemscope_value}" itemtype="https://schema.org/BreadcrumbList"><span itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></span> &rsaquo; <span class="current" itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><meta itemprop="item" content="http://test.host/about" /><meta itemprop="position" content="2" /></span></div>),
+                     breadcrumbs(semantic: true).to_s
   end
 
   test "doesn't show root alone" do
@@ -74,14 +74,14 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "displays single fragment" do
     breadcrumb :root
-    assert_dom_equal %{<div class="breadcrumbs"><span class="current">Home</span></div>},
-                 breadcrumbs(display_single_fragment: true).to_s
+    assert_dom_equal %(<div class="breadcrumbs"><span class="current">Home</span></div>),
+                     breadcrumbs(display_single_fragment: true).to_s
   end
 
   test "displays single non-root fragment" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><span class="current">About</span></div>},
-                 breadcrumbs(autoroot: false, display_single_fragment: true).to_s
+    assert_dom_equal %(<div class="breadcrumbs"><span class="current">About</span></div>),
+                     breadcrumbs(autoroot: false, display_single_fragment: true).to_s
   end
 
   test "no breadcrumb" do
@@ -90,20 +90,20 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "links current breadcrumb" do
     breadcrumb :with_root
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about" class="current">About</a></div>},
-                 breadcrumbs(link_current: true).to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about" class="current">About</a></div>),
+                     breadcrumbs(link_current: true).to_s
   end
 
   test "pretext" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><span class="pretext">You are here:</span> <a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs(pretext: "You are here:").to_s
+    assert_dom_equal %(<div class="breadcrumbs"><span class="pretext">You are here:</span> <a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs(pretext: "You are here:").to_s
   end
 
   test "posttext" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span> <span class="posttext">text after breadcrumbs</span></div>},
-                 breadcrumbs(posttext: "text after breadcrumbs").to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span> <span class="posttext">text after breadcrumbs</span></div>),
+                     breadcrumbs(posttext: "text after breadcrumbs").to_s
   end
 
   test "autoroot disabled" do
@@ -113,50 +113,50 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "separator" do
     breadcrumb :with_root
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &raquo; <span class="current">About</span></div>},
-                 breadcrumbs(separator: " &raquo; ").to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &raquo; <span class="current">About</span></div>),
+                     breadcrumbs(separator: " &raquo; ").to_s
   end
 
   test "element id" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs" id="custom_id"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs(id: "custom_id").to_s
+    assert_dom_equal %(<div class="breadcrumbs" id="custom_id"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs(id: "custom_id").to_s
   end
 
   test "custom container class" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="custom_class"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs(class: "custom_class").to_s
+    assert_dom_equal %(<div class="custom_class"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs(class: "custom_class").to_s
   end
 
   test "custom current class" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="custom_current_class">About</span></div>},
-                 breadcrumbs(current_class: "custom_current_class").to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="custom_current_class">About</span></div>),
+                     breadcrumbs(current_class: "custom_current_class").to_s
   end
 
   test "custom pretext class" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><span class="custom_pretext_class">You are here:</span> <a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs(pretext: "You are here:", pretext_class: "custom_pretext_class").to_s
+    assert_dom_equal %(<div class="breadcrumbs"><span class="custom_pretext_class">You are here:</span> <a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs(pretext: "You are here:", pretext_class: "custom_pretext_class").to_s
   end
 
   test "custom posttext class" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span> <span class="custom_posttext_class">after breadcrumbs</span></div>},
-                 breadcrumbs(posttext: "after breadcrumbs", posttext_class: "custom_posttext_class").to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span> <span class="custom_posttext_class">after breadcrumbs</span></div>),
+                     breadcrumbs(posttext: "after breadcrumbs", posttext_class: "custom_posttext_class").to_s
   end
 
   test "unsafe html" do
     breadcrumb :with_unsafe_html
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test &lt;strong&gt;bold text&lt;/strong&gt;</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test &lt;strong&gt;bold text&lt;/strong&gt;</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "safe html" do
     breadcrumb :with_safe_html
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test <strong>bold text</strong></span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test <strong>bold text</strong></span></div>),
+                     breadcrumbs.to_s
   end
 
   test "parent breadcrumb" do
@@ -195,7 +195,7 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "link keys" do
     breadcrumb :basic
-    assert_equal [:root, :basic], breadcrumbs.keys
+    assert_equal %i[root basic], breadcrumbs.keys
   end
 
   test "using breadcrumbs as array" do
@@ -233,54 +233,54 @@ class HelperMethodsTest < ActionView::TestCase
       end
     end
 
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/about">Test</a> &rsaquo; <span class="current">Other Link</span></div>},
-                 breadcrumbs(autoroot: false).to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/about">Test</a> &rsaquo; <span class="current">Other Link</span></div>),
+                     breadcrumbs(autoroot: false).to_s
   end
 
   test "without link" do
     breadcrumb :without_link
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; Also without link &rsaquo; <span class="current">Without link</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; Also without link &rsaquo; <span class="current">Without link</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "view context" do
     breadcrumb :using_view_helper
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">TestTest</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">TestTest</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "multiple arguments" do
     breadcrumb :with_multiple_arguments, "One", "Two", "Three"
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">First OneOne then TwoTwo then ThreeThree</a> &rsaquo; <span class="current">One and Two and Three</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">First OneOne then TwoTwo then ThreeThree</a> &rsaquo; <span class="current">One and Two and Three</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "from views folder" do
     breadcrumb :from_views
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Breadcrumb From View</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Breadcrumb From View</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "with_breadcrumb" do
     breadcrumb :basic
 
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs.to_s
 
     with_breadcrumb(:with_parent_object, issues(:one)) do
-      assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/projects/1">Test Project</a> &rsaquo; <span class="current">Test Issue</span></div>},
-                   breadcrumbs.to_s
+      assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/projects/1">Test Project</a> &rsaquo; <span class="current">Test Issue</span></div>),
+                       breadcrumbs.to_s
     end
 
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "calling breadcrumbs helper twice" do
     breadcrumb :with_parent
     2.times do
-      assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">About</a> &rsaquo; <span class="current">Contact</span></div>},
-                   breadcrumbs.to_s
+      assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/about">About</a> &rsaquo; <span class="current">Contact</span></div>),
+                       breadcrumbs.to_s
     end
   end
 
@@ -302,7 +302,7 @@ class HelperMethodsTest < ActionView::TestCase
     self.request = OpenStruct.new(fullpath: "/testpath?a=1&b=2")
 
     breadcrumb :basic
-    assert_equal "/about", breadcrumbs(:link_current_to_request_path => false).last.url
+    assert_equal "/about", breadcrumbs(link_current_to_request_path: false).last.url
   end
 
   test "calling the breadcrumb method with wrong arguments" do
@@ -321,14 +321,14 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "inferred breadcrumb" do
     breadcrumb Project.first
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test Project</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">Test Project</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "inferred parent" do
     breadcrumb :with_inferred_parent
 
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/projects/1">Test Project</a> &rsaquo; <span class="current">Test</span></div>},
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <a href="/projects/1">Test Project</a> &rsaquo; <span class="current">Test</span></div>),
                      breadcrumbs.to_s
   end
 
@@ -336,44 +336,44 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "default style" do
     breadcrumb :basic
-    assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>},
-                 breadcrumbs.to_s
+    assert_dom_equal %(<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="current">About</span></div>),
+                     breadcrumbs.to_s
   end
 
   test "ordered list style" do
     breadcrumb :basic
-    assert_dom_equal %{<ol class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ol>},
-                 breadcrumbs(style: :ol).to_s
+    assert_dom_equal %(<ol class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ol>),
+                     breadcrumbs(style: :ol).to_s
   end
 
   test "unordered list style" do
     breadcrumb :basic
-    assert_dom_equal %{<ul class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ul>},
-                 breadcrumbs(style: :ul).to_s
+    assert_dom_equal %(<ul class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ul>),
+                     breadcrumbs(style: :ul).to_s
   end
 
   test "bootstrap style" do
     breadcrumb :basic
-    assert_dom_equal %{<ol class="breadcrumb"><li><a href="/">Home</a></li><li class="active">About</li></ol>},
-                 breadcrumbs(style: :bootstrap).to_s
+    assert_dom_equal %(<ol class="breadcrumb"><li><a href="/">Home</a></li><li class="active">About</li></ol>),
+                     breadcrumbs(style: :bootstrap).to_s
   end
 
   test "foundation5 style" do
     breadcrumb :basic
-    assert_dom_equal %{<ul class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ul>},
-	         breadcrumbs(style: :foundation5).to_s
+    assert_dom_equal %(<ul class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ul>),
+                     breadcrumbs(style: :foundation5).to_s
   end
 
   test "custom container and fragment tags" do
     breadcrumb :basic
-    assert_dom_equal %{<c class="breadcrumbs"><f><a href="/">Home</a></f> &rsaquo; <f class="current">About</f></c>},
-                 breadcrumbs(container_tag: :c, fragment_tag: :f).to_s
+    assert_dom_equal %(<c class="breadcrumbs"><f><a href="/">Home</a></f> &rsaquo; <f class="current">About</f></c>),
+                     breadcrumbs(container_tag: :c, fragment_tag: :f).to_s
   end
 
   test "custom semantic container and fragment tags" do
     breadcrumb :basic
-    assert_dom_equal %Q{<c class="breadcrumbs"><f itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><a itemprop="url" href="/"><span itemprop="title">Home</span></a></f> &rsaquo; <f class="current" itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">About</span><meta itemprop="url" content="http://test.host/about" /></f></c>},
-                 breadcrumbs(container_tag: :c, fragment_tag: :f, semantic: true).to_s
+    assert_dom_equal %(<c class="breadcrumbs" itemscope="#{itemscope_value}" itemtype="https://schema.org/BreadcrumbList"><f itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></f> &rsaquo; <f class="current" itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><meta itemprop="item" content="http://test.host/about" /><meta itemprop="position" content="2" /></f></c>),
+                     breadcrumbs(container_tag: :c, fragment_tag: :f, semantic: true).to_s
   end
 
   test "unknown style" do
@@ -384,12 +384,12 @@ class HelperMethodsTest < ActionView::TestCase
   end
 
   test "register style" do
-    Gretel.register_style :test_style, { container_tag: :one, fragment_tag: :two }
+    Gretel.register_style :test_style, container_tag: :one, fragment_tag: :two
 
     breadcrumb :basic
 
-    assert_dom_equal %{<one class="breadcrumbs"><two><a href="/">Home</a></two><two class="current">About</two></one>},
-                 breadcrumbs(style: :test_style).to_s
+    assert_dom_equal %(<one class="breadcrumbs"><two><a href="/">Home</a></two><two class="current">About</two></one>),
+                     breadcrumbs(style: :test_style).to_s
   end
 
   # Configuration reload
@@ -532,7 +532,7 @@ class HelperMethodsTest < ActionView::TestCase
     assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home (loaded)</a> &rsaquo; <span class="current">About (loaded)</span></div>}, breadcrumbs.to_s
   end
 
-private
+  private
 
   def setup_loading_from_tmp_folder
     path = Rails.root.join("tmp", "testcrumbs")


### PR DESCRIPTION
Sunsetting support for data-vocabulary in April 2020, this pull request implements the breadcrumbs using schema.org structured data markup. I've followed https://developers.google.com/search/docs/data-types/breadcrumb as a guide and implemented a basic implementation of it. 
